### PR TITLE
Add MySQL Java Connector 6.0.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ ebean {
 dependencies {
     compile 'io.ebean:ebean:11.9.1'
     compile 'ch.qos.logback:logback-classic:1.2.3'
+    compile 'mysql:mysql-connector-java:6.0.6'
 
     testCompile 'org.avaje.composite:composite-testing:3.1'
 }


### PR DESCRIPTION
This will be useful in case developer needs to use MySQL driver `com.mysql.jdbc.Driver` not H2 drive `org.h2.Driver`